### PR TITLE
refactor(ui): 서버 대시보드 탭 구조를 발송 흐름 기준으로 개편

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,7 +7,6 @@ import { useEffect, useRef } from "react";
 
 import { BookingConfirmDialog } from "@/components/BookingConfirmDialog";
 import { VisitPickupConfirmDialog } from "@/components/VisitPickupConfirmDialog";
-import { DispatchPanel } from "@/components/DispatchPanel";
 import { OrderTable } from "@/components/OrderTable";
 import { OrderTableSkeleton } from "@/components/OrderTableSkeleton";
 import { StatusFilter } from "@/components/StatusFilter";
@@ -24,16 +23,17 @@ import {
   useUpdateGroupStatus,
 } from "@/hooks/useOrders";
 
-import { countGroupsByStatus, groupOrdersByOrderId } from "@/lib/groupOrders";
+import { countGroupsByServerFilter, countGroupsByStatus, filterOrdersByServerFilter, groupOrdersByOrderId } from "@/lib/groupOrders";
 
-import type { DeliveryType, OrderStatus } from "@/types";
+import type { DeliveryType, OrderStatus, ServerFilter } from "@/types";
 
 const isServerMode = process.env.NEXT_PUBLIC_DEPLOY_MODE === "server";
 
 export function Dashboard() {
   const [statusFilter, setStatusFilter] = useState<OrderStatus | undefined>(
-    "pending"
+    isServerMode ? undefined : "pending"
   );
+  const [serverFilter, setServerFilter] = useState<ServerFilter | undefined>("waiting");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [isBookingDialogOpen, setIsBookingDialogOpen] = useState(false);
   const [isVisitPickupDialogOpen, setIsVisitPickupDialogOpen] = useState(false);
@@ -45,7 +45,7 @@ export function Dashboard() {
   const bookingPhase = useRef<"idle" | "waiting" | "monitoring">("idle");
   const queryClient = useQueryClient();
 
-  const { data, isLoading, isError } = useOrders(statusFilter);
+  const { data, isLoading, isError } = useOrders(isServerMode ? undefined : statusFilter);
   const syncMutation = useSyncOrders();
   const updateGroupStatusMutation = useUpdateGroupStatus();
   const updateGroupDeliveryTypeMutation = useUpdateGroupDeliveryType();
@@ -64,15 +64,22 @@ export function Dashboard() {
   });
   const isCookieExpired = cookieStatusQuery.data?.valid === false;
 
-  const orders = data?.orders ?? [];
   const lastSyncTime = data?.lastSyncTime ?? null;
 
   // 전체 주문(필터 무관)을 기반으로 상태별 카운트 계산
+  // 서버 모드: useOrders(undefined)로 전체 조회 후 클라이언트 필터링
+  // 로컬 모드: allOrdersQuery는 카운트용, data는 API 필터링된 목록
   const allOrdersQuery = useOrders(undefined);
   const allOrders = allOrdersQuery.data?.orders ?? [];
 
   // 주문(orderId) 그룹 기준 상태별 카운트 — 화면에 보이는 숫자는 모두 주문 단위
   const statusCounts = countGroupsByStatus(allOrders);
+  const serverStatusCounts = countGroupsByServerFilter(allOrders);
+
+  // 서버 모드: 클라이언트 필터링 / 로컬 모드: API 필터링 결과 사용
+  const orders = isServerMode
+    ? filterOrdersByServerFilter(allOrders, serverFilter)
+    : (data?.orders ?? []);
 
   const selectedOrders = orders.filter((o) => selectedIds.has(o.id));
   const selectedGroups = groupOrdersByOrderId(selectedOrders);
@@ -103,8 +110,8 @@ export function Dashboard() {
     }
   }, [allOrders, queryClient]);
 
-  function handleStatusFilterChange(status: OrderStatus | undefined) {
-    setStatusFilter(status);
+  function handleStatusFilterChange(status: OrderStatus | ServerFilter | undefined) {
+    setStatusFilter(status as OrderStatus | undefined);
     setSelectedIds(new Set()); // 필터 변경 시 선택 초기화
   }
 
@@ -279,9 +286,13 @@ export function Dashboard() {
 
       {/* 상태 필터 */}
       <StatusFilter
-        currentStatus={statusFilter}
-        counts={statusCounts}
-        onStatusChange={handleStatusFilterChange}
+        currentStatus={isServerMode ? serverFilter : statusFilter}
+        counts={isServerMode ? serverStatusCounts : statusCounts}
+        onStatusChange={
+          isServerMode
+            ? (s) => setServerFilter(s as ServerFilter | undefined)
+            : handleStatusFilterChange
+        }
         isServerMode={isServerMode}
       />
 
@@ -357,9 +368,6 @@ export function Dashboard() {
           </div>
         </div>
       )}
-
-      {/* 발송처리 패널 (서버 모드에서만 표시) */}
-      {isServerMode && <DispatchPanel orders={allOrders} isServerMode={isServerMode} />}
 
       {/* 예약 확인 다이얼로그 (로컬 모드만) */}
       {!isServerMode && <BookingConfirmDialog

--- a/src/components/OrderTable.tsx
+++ b/src/components/OrderTable.tsx
@@ -381,6 +381,31 @@ function GroupRows({
                 </span>
               )}
             </div>
+          ) : !selectable && groupStatus === "booked" ? (
+            /* 서버 모드 booked: 운송장 상태 + 수동 발송완료 */
+            <div className="flex flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">운송장 대기중</span>
+              <Select
+                value={groupStatus}
+                onValueChange={(v) =>
+                  onGroupStatusChange(group.orderId, v as OrderStatus)
+                }
+              >
+                <SelectTrigger className="w-24 h-6 text-[11px]">
+                  <span data-slot="select-value" className="flex flex-1 text-left">
+                    상태 변경
+                  </span>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="dispatched" className="text-xs">
+                    발송완료
+                  </SelectItem>
+                  <SelectItem value="booked" className="text-xs">
+                    예약완료
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           ) : (
             <Select
               value={groupStatus}
@@ -403,11 +428,6 @@ function GroupRows({
                 <SelectItem value="failed" className="text-xs">
                   실패
                 </SelectItem>
-                {!selectable && groupStatus === "booked" && (
-                  <SelectItem value="dispatched" className="text-xs">
-                    발송완료
-                  </SelectItem>
-                )}
               </SelectContent>
             </Select>
           )}

--- a/src/components/OrderTable.tsx
+++ b/src/components/OrderTable.tsx
@@ -403,6 +403,11 @@ function GroupRows({
                 <SelectItem value="failed" className="text-xs">
                   실패
                 </SelectItem>
+                {!selectable && groupStatus === "booked" && (
+                  <SelectItem value="dispatched" className="text-xs">
+                    발송완료
+                  </SelectItem>
+                )}
               </SelectContent>
             </Select>
           )}

--- a/src/components/StatusFilter.tsx
+++ b/src/components/StatusFilter.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 
-import type { OrderStatus } from "@/types";
+import type { OrderStatus, ServerFilter } from "@/types";
 
 interface StatusCount {
   all: number;
@@ -14,24 +14,39 @@ interface StatusCount {
   dispatched: number;
 }
 
+interface ServerStatusCount {
+  all: number;
+  waiting: number;
+  dispatched: number;
+  dispatch_failed: number;
+}
+
 interface StatusFilterProps {
-  currentStatus: OrderStatus | undefined;
-  counts: StatusCount;
-  onStatusChange: (status: OrderStatus | undefined) => void;
-  /** 서버 모드 여부 — false이면 발송완료 탭 숨김 */
+  currentStatus: OrderStatus | ServerFilter | undefined;
+  counts: StatusCount | ServerStatusCount;
+  onStatusChange: (status: OrderStatus | ServerFilter | undefined) => void;
   isServerMode?: boolean;
 }
 
-const TABS: {
+const LOCAL_TABS: {
   key: OrderStatus | undefined;
   label: string;
   countKey: keyof StatusCount;
-  serverOnly?: boolean;
 }[] = [
   { key: "pending", label: "대기", countKey: "pending" },
   { key: "booked", label: "예약완료", countKey: "booked" },
-  { key: "dispatched", label: "발송완료", countKey: "dispatched", serverOnly: true },
   { key: "failed", label: "실패", countKey: "failed" },
+  { key: undefined, label: "전체", countKey: "all" },
+];
+
+const SERVER_TABS: {
+  key: ServerFilter | undefined;
+  label: string;
+  countKey: keyof ServerStatusCount;
+}[] = [
+  { key: "waiting", label: "대기", countKey: "waiting" },
+  { key: "dispatched", label: "발송완료", countKey: "dispatched" },
+  { key: "dispatch_failed", label: "실패", countKey: "dispatch_failed" },
   { key: undefined, label: "전체", countKey: "all" },
 ];
 
@@ -41,13 +56,11 @@ export function StatusFilter({
   onStatusChange,
   isServerMode = false,
 }: StatusFilterProps) {
-  const visibleTabs = isServerMode
-    ? TABS
-    : TABS.filter((tab) => !tab.serverOnly);
+  const tabs = isServerMode ? SERVER_TABS : LOCAL_TABS;
 
   return (
     <div className="flex gap-1 flex-wrap">
-      {visibleTabs.map((tab) => (
+      {tabs.map((tab) => (
         <Button
           key={tab.label}
           variant={currentStatus === tab.key ? "default" : "outline"}
@@ -56,7 +69,7 @@ export function StatusFilter({
         >
           {tab.label}
           <span className="ml-1 text-xs opacity-70">
-            ({counts[tab.countKey]})
+            ({(counts as unknown as Record<string, number>)[tab.countKey]})
           </span>
         </Button>
       ))}

--- a/src/lib/groupOrders.ts
+++ b/src/lib/groupOrders.ts
@@ -1,4 +1,4 @@
-import type { Order, OrderGroup, OrderStatus } from "@/types";
+import type { Order, OrderGroup, OrderStatus, ServerFilter } from "@/types";
 
 /**
  * 같은 orderId를 가진 주문을 하나의 그룹으로 묶는다.
@@ -88,4 +88,55 @@ export function countGroupsByStatus(orders: Order[]): {
   }
 
   return counts;
+}
+
+/** 서버 대시보드용 — 발송 흐름 기준 그룹 카운트 */
+export function countGroupsByServerFilter(orders: Order[]): {
+  all: number;
+  waiting: number;
+  dispatched: number;
+  dispatch_failed: number;
+} {
+  const groups = groupOrdersByOrderId(orders);
+  const counts = { all: groups.length, waiting: 0, dispatched: 0, dispatch_failed: 0 };
+
+  for (const group of groups) {
+    const status = getGroupStatus(group.orders);
+    const dispatchStatus = group.orders[0]?.dispatchStatus;
+
+    if (status === "dispatched") {
+      counts.dispatched++;
+    } else if (status === "booked" && dispatchStatus === "dispatch_failed") {
+      counts.dispatch_failed++;
+    } else if (status === "booked") {
+      counts.waiting++;
+    }
+  }
+
+  return counts;
+}
+
+/** 서버 필터에 따라 주문 필터링 (전체: undefined) */
+export function filterOrdersByServerFilter(
+  orders: Order[],
+  filter: ServerFilter | undefined
+): Order[] {
+  if (!filter) return orders;
+
+  const groups = groupOrdersByOrderId(orders);
+  const matchingOrderIds = new Set<string>();
+
+  for (const group of groups) {
+    const status = getGroupStatus(group.orders);
+    const dispatchStatus = group.orders[0]?.dispatchStatus;
+
+    const match =
+      (filter === "waiting" && status === "booked" && dispatchStatus !== "dispatch_failed") ||
+      (filter === "dispatched" && status === "dispatched") ||
+      (filter === "dispatch_failed" && status === "booked" && dispatchStatus === "dispatch_failed");
+
+    if (match) matchingOrderIds.add(group.orderId);
+  }
+
+  return orders.filter((o) => matchingOrderIds.has(o.orderId));
 }

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -108,16 +108,30 @@ export function updateGroupStatus(
   orderId: string,
   status: OrderStatus
 ): void {
-  const allowedStatuses = new Set(["pending", "booked", "failed"]);
+  const allowedStatuses = new Set(["pending", "booked", "failed", "dispatched"]);
   if (!allowedStatuses.has(status)) {
     throw new Error(`허용되지 않은 상태입니다: ${status}`);
   }
 
   const now = new Date().toISOString();
-  db.update(orders)
-    .set({ status, updatedAt: now })
-    .where(eq(orders.orderId, orderId))
-    .run();
+
+  if (status === "dispatched") {
+    // 수동 발송완료: status + dispatchStatus + dispatchedAt 일괄 설정
+    db.update(orders)
+      .set({
+        status,
+        dispatchStatus: "dispatched" as DispatchStatus,
+        dispatchedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(orders.orderId, orderId))
+      .run();
+  } else {
+    db.update(orders)
+      .set({ status, updatedAt: now })
+      .where(eq(orders.orderId, orderId))
+      .run();
+  }
 }
 
 /** 주문 그룹 택배유형 일괄 변경 (orderId 기준) */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,9 @@ export type OrderStatus = "pending" | "booking" | "booked" | "failed" | "skipped
 /** 발송처리 상태 */
 export type DispatchStatus = "pending_dispatch" | "dispatched" | "dispatch_failed";
 
+/** 서버 대시보드 필터 (발송 흐름 기준) */
+export type ServerFilter = "waiting" | "dispatched" | "dispatch_failed";
+
 /** 배송 추적 상태 (네이버 API 기반) */
 export type DeliveryTrackingStatus = "delivering" | "delivered";
 


### PR DESCRIPTION
## 관련 이슈
Closes #28

## 변경 내용
- 서버 대시보드 탭: **대기**(운송장 대기 중) / **발송완료** / **실패**(발송처리 실패) / **전체** 로 재구성
- 로컬 대시보드 탭: 대기 / 예약완료 / 실패 / 전체 유지 (서버전용 발송완료 탭 제거)
- 하단 `DispatchPanel` 제거 (자동 모드 전용 운영)
- `ServerFilter` 타입 추가 (`waiting | dispatched | dispatch_failed`)
- `countGroupsByServerFilter`, `filterOrdersByServerFilter` 함수 추가
- 서버 모드 필터링은 전체 주문을 받아 클라이언트에서 처리 (API 변경 없음)

## 코드 리뷰 결과
- [x] 보안 감사 통과
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료
- [x] 코드 품질 확인

## 테스트
- [x] Vitest 25개 통과
- [x] Next.js 빌드 성공 (타입 에러 없음)