### PR TITLE
chore(auth): JWT 검증 시 허용 알고리즘 명시

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -32,7 +32,9 @@ export async function verifySessionToken(
   token: string
 ): Promise<{ sub: string } | null> {
   try {
-    const { payload } = await jwtVerify(token, SECRET);
+    const { payload } = await jwtVerify(token, SECRET, {
+      algorithms: ["HS256"],
+    });
     return payload as { sub: string };
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- \`jwtVerify\` 호출에 \`algorithms: ["HS256"]\` 옵션 추가
- 생성 시 사용한 \`HS256\` 알고리즘으로 검증 범위 고정

## Test plan

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npx vitest run\` 33건 통과
- [ ] 배포 후 로그인/로그아웃/세션 유지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)