### PR TITLE
chore(internal-api): 요청 body 런타임 검증 추가 (zod)

### DIFF
--- a/src/app/api/internal/booking-result/route.ts
+++ b/src/app/api/internal/booking-result/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 
 import { verifyInternalApiKey } from "@/lib/internal-auth";
 import {
@@ -7,24 +8,38 @@ import {
   upsertOrdersFromLocal,
 } from "@/lib/orders";
 
-import type { OrderStatus } from "@/types";
+const orderItemSchema = z.object({
+  productOrderId: z.string().min(1),
+  orderDate: z.string(),
+  productName: z.string(),
+  quantity: z.number(),
+  optionInfo: z.string().nullable(),
+  totalPrice: z.number().nullable(),
+  recipientName: z.string(),
+  recipientPhone: z.string(),
+  recipientAddress: z.string(),
+  recipientAddressDetail: z.string().nullable(),
+  recipientZipCode: z.string(),
+  shippingMemo: z.string().nullable(),
+  isNextDayEligible: z.boolean(),
+  selectedDeliveryType: z.enum(["domestic", "nextDay"]),
+});
 
-interface OrderItem {
-  productOrderId: string;
-  orderDate: string;
-  productName: string;
-  quantity: number;
-  optionInfo: string | null;
-  totalPrice: number | null;
-  recipientName: string;
-  recipientPhone: string;
-  recipientAddress: string;
-  recipientAddressDetail: string | null;
-  recipientZipCode: string;
-  shippingMemo: string | null;
-  isNextDayEligible: boolean;
-  selectedDeliveryType: "domestic" | "nextDay";
-}
+const bodySchema = z.object({
+  orderId: z.string().min(1),
+  status: z.enum([
+    "pending",
+    "booking",
+    "booked",
+    "failed",
+    "skipped",
+    "dispatched",
+  ]),
+  bookingResult: z.string().optional(),
+  bookingReservationNo: z.string().optional(),
+  error: z.string().optional(),
+  orderItems: z.array(orderItemSchema).optional(),
+});
 
 /** POST /api/internal/booking-result — 로컬 예약 결과 수신 후 서버 DB 업데이트 (없으면 INSERT) */
 export async function POST(request: NextRequest) {
@@ -32,24 +47,16 @@ export async function POST(request: NextRequest) {
   if (unauthorized) return unauthorized;
 
   try {
-    const body = (await request.json()) as {
-      orderId: string;
-      status: OrderStatus;
-      bookingResult?: string;
-      bookingReservationNo?: string;
-      error?: string;
-      orderItems?: OrderItem[];
-    };
-
-    if (!body.orderId || !body.status) {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "orderId와 status가 필요합니다" },
+        { error: "요청 형식이 올바르지 않습니다" },
         { status: 400 }
       );
     }
+    const body = parsed.data;
 
     if (body.status === "booked") {
-      // orderItems가 있으면 upsert (서버 DB에 없는 주문도 INSERT)
       if (body.orderItems && body.orderItems.length > 0) {
         upsertOrdersFromLocal(
           body.orderId,
@@ -58,7 +65,6 @@ export async function POST(request: NextRequest) {
           body.bookingReservationNo
         );
       } else {
-        // orderItems 없으면 기존 방식 (UPDATE only)
         updateOrdersByOrderId(
           body.orderId,
           "booked",

--- a/src/app/api/internal/cookies/route.ts
+++ b/src/app/api/internal/cookies/route.ts
@@ -2,10 +2,15 @@ import fs from "fs";
 import path from "path";
 
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 
 import { verifyInternalApiKey } from "@/lib/internal-auth";
 
 const COOKIES_PATH = path.join(process.cwd(), "data", "cookies.json");
+
+const bodySchema = z.object({
+  cookies: z.array(z.record(z.string(), z.unknown())).min(1),
+});
 
 /** POST /api/internal/cookies — 로컬에서 GS택배 쿠키 수신 후 저장 */
 export async function POST(request: NextRequest) {
@@ -13,26 +18,24 @@ export async function POST(request: NextRequest) {
   if (unauthorized) return unauthorized;
 
   try {
-    const body = (await request.json()) as {
-      cookies?: Array<Record<string, unknown>>;
-    };
-
-    if (!body.cookies || !Array.isArray(body.cookies)) {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "cookies 배열이 필요합니다" },
+        { error: "요청 형식이 올바르지 않습니다" },
         { status: 400 }
       );
     }
+    const { cookies } = parsed.data;
 
     const dir = path.dirname(COOKIES_PATH);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(COOKIES_PATH, JSON.stringify(body.cookies, null, 2));
+    fs.writeFileSync(COOKIES_PATH, JSON.stringify(cookies, null, 2));
 
     console.log(
-      `[internal/cookies] GS택배 쿠키 저장 완료 (${body.cookies.length}개)`
+      `[internal/cookies] GS택배 쿠키 저장 완료 (${cookies.length}개)`
     );
     return NextResponse.json({
-      message: `쿠키 ${body.cookies.length}개 저장 완료`,
+      message: `쿠키 ${cookies.length}개 저장 완료`,
     });
   } catch (error) {
     console.error("[internal/cookies] 저장 실패:", error);

--- a/src/app/api/internal/tracking/route.ts
+++ b/src/app/api/internal/tracking/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 
 import { verifyInternalApiKey } from "@/lib/internal-auth";
 import {
@@ -6,29 +7,34 @@ import {
   updateTrackingNumbers,
 } from "@/lib/orders";
 
+const bodySchema = z.object({
+  items: z
+    .array(
+      z.object({
+        orderId: z.string().min(1),
+        trackingNumber: z.string().min(1),
+      })
+    )
+    .min(1),
+});
+
 /** POST /api/internal/tracking — 로컬에서 운송장번호 수신 후 서버 DB 업데이트 */
 export async function POST(request: NextRequest) {
   const unauthorized = verifyInternalApiKey(request);
   if (unauthorized) return unauthorized;
 
   try {
-    const body = (await request.json()) as {
-      items?: Array<{
-        orderId: string;
-        trackingNumber: string;
-      }>;
-    };
-
-    if (!body.items || !Array.isArray(body.items) || body.items.length === 0) {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "items 배열이 필요합니다" },
+        { error: "요청 형식이 올바르지 않습니다" },
         { status: 400 }
       );
     }
+    const { items } = parsed.data;
 
     let updated = 0;
-    for (const item of body.items) {
-      if (!item.orderId || !item.trackingNumber) continue;
+    for (const item of items) {
       updateTrackingNumbers(item.orderId, item.trackingNumber);
       addBookingLogByOrderId(
         item.orderId,


### PR DESCRIPTION
## Summary

- 3개 internal 라우트(cookies, booking-result, tracking)에서 request body에 zod \`safeParse\` 적용
- 검증 실패 시 일반화된 400 반환
- 기존 타입 단언(\`as\`) 제거

## Test plan

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npx vitest run\` 33건 통과
- [ ] 배포 후 로컬 → 서버 동기화 정상 동작 확인 (예약 결과, 쿠키, 운송장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)