### PR TITLE
chore(api): 파일 서빙 엔드포인트 경로 검증 강화

### DIFF
--- a/src/app/api/screenshots/[filename]/route.test.ts
+++ b/src/app/api/screenshots/[filename]/route.test.ts
@@ -1,0 +1,55 @@
+import { join, sep } from "path";
+import { describe, expect, it } from "vitest";
+
+import { resolveScreenshotPath } from "./route";
+
+const DIR = join(process.cwd(), "data", "screenshots");
+
+describe("resolveScreenshotPath", () => {
+  it("허용된 png 파일명은 절대 경로를 반환", () => {
+    expect(resolveScreenshotPath("foo.png")).toBe(join(DIR, "foo.png"));
+  });
+
+  it("허용된 jpg/jpeg도 통과", () => {
+    expect(resolveScreenshotPath("a.jpg")).toBe(join(DIR, "a.jpg"));
+    expect(resolveScreenshotPath("b.jpeg")).toBe(join(DIR, "b.jpeg"));
+  });
+
+  it("대문자 확장자도 허용", () => {
+    expect(resolveScreenshotPath("foo.PNG")).toBe(join(DIR, "foo.PNG"));
+  });
+
+  it("디렉토리 상위 이동(..)은 차단", () => {
+    expect(resolveScreenshotPath("../secret.png")).toBeNull();
+    expect(resolveScreenshotPath("..")).toBeNull();
+  });
+
+  it("슬래시/백슬래시 포함 파일명은 차단", () => {
+    expect(resolveScreenshotPath("sub/foo.png")).toBeNull();
+    expect(resolveScreenshotPath("sub\\foo.png")).toBeNull();
+  });
+
+  it("널 바이트 차단", () => {
+    expect(resolveScreenshotPath("foo\0.png")).toBeNull();
+  });
+
+  it("확장자 화이트리스트 외 거부", () => {
+    expect(resolveScreenshotPath("foo.txt")).toBeNull();
+    expect(resolveScreenshotPath("foo.exe")).toBeNull();
+    expect(resolveScreenshotPath("foo")).toBeNull();
+  });
+
+  it("빈 문자열 거부", () => {
+    expect(resolveScreenshotPath("")).toBeNull();
+  });
+
+  it("절대 경로 입력은 prefix 검증에서 차단", () => {
+    expect(resolveScreenshotPath("/etc/passwd.png")).toBeNull();
+  });
+
+  it("결과 경로는 SCREENSHOTS_DIR prefix 하위에 위치", () => {
+    const result = resolveScreenshotPath("foo.png");
+    expect(result).not.toBeNull();
+    expect(result!.startsWith(DIR + sep)).toBe(true);
+  });
+});

--- a/src/app/api/screenshots/[filename]/route.ts
+++ b/src/app/api/screenshots/[filename]/route.ts
@@ -1,9 +1,36 @@
 import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { extname, join, resolve, sep } from "path";
 
 import { NextRequest, NextResponse } from "next/server";
 
 const SCREENSHOTS_DIR = join(process.cwd(), "data", "screenshots");
+
+const CONTENT_TYPE_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+};
+
+/** 요청된 filename을 정규화해 안전한 절대 경로를 반환. 허용 범위를 벗어나면 null. */
+export function resolveScreenshotPath(filename: string): string | null {
+  if (
+    !filename ||
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    filename.includes("..") ||
+    filename.includes("\0")
+  ) {
+    return null;
+  }
+
+  const ext = extname(filename).toLowerCase();
+  if (!(ext in CONTENT_TYPE_BY_EXT)) return null;
+
+  const resolved = resolve(SCREENSHOTS_DIR, filename);
+  if (!resolved.startsWith(SCREENSHOTS_DIR + sep)) return null;
+
+  return resolved;
+}
 
 export async function GET(
   _request: NextRequest,
@@ -11,18 +38,20 @@ export async function GET(
 ) {
   const { filename } = await params;
 
-  // 경로 조작 방지
-  if (filename.includes("..") || filename.includes("/")) {
+  const filepath = resolveScreenshotPath(filename);
+  if (!filepath) {
     return NextResponse.json({ error: "잘못된 파일명" }, { status: 400 });
   }
-
-  const filepath = join(SCREENSHOTS_DIR, filename);
   if (!existsSync(filepath)) {
     return NextResponse.json({ error: "파일 없음" }, { status: 404 });
   }
 
+  const ext = extname(filepath).toLowerCase();
   const buffer = readFileSync(filepath);
   return new NextResponse(buffer, {
-    headers: { "Content-Type": "image/png", "Cache-Control": "public, max-age=3600" },
+    headers: {
+      "Content-Type": CONTENT_TYPE_BY_EXT[ext] ?? "application/octet-stream",
+      "Cache-Control": "public, max-age=3600",
+    },
   });
 }


### PR DESCRIPTION
## Summary

- 스크린샷 라우트에 \`resolveScreenshotPath\` 헬퍼 도입
- 경로 정규화(\`path.resolve\`) + 허용 디렉토리 prefix 검증
- 확장자 화이트리스트(\`.png\`, \`.jpg\`, \`.jpeg\`)
- Content-Type을 확장자 기반으로 선택

## Test plan

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npx vitest run\` 43건 통과 (신규 10건 포함)
- [ ] 배포 후 실제 스크린샷 URL 정상 서빙 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)