### PR TITLE
chore(api): 디버그 엔드포인트 프로덕션 가드 적용

### DIFF
--- a/src/app/api/dispatch/debug-scrape/route.ts
+++ b/src/app/api/dispatch/debug-scrape/route.ts
@@ -3,8 +3,12 @@ import { newPage } from "@/lib/gs-delivery/browser";
 import { ensureLoggedIn } from "@/lib/gs-delivery/auth";
 import { GS_URLS, ACTION_DELAY_MS } from "@/lib/gs-delivery/selectors";
 
-/** GET /api/dispatch/debug-scrape — 예약조회 페이지 HTML 구조 덤프 (디버그용) */
+/** GET /api/dispatch/debug-scrape — 예약조회 페이지 HTML 구조 덤프 (디버그용, 개발 환경 전용) */
 export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+
   const page = await newPage();
   try {
     await ensureLoggedIn(page);


### PR DESCRIPTION
## Summary

- \`debug-scrape\` 라우트에 \`NODE_ENV === "production"\` 조건 가드 추가
- 프로덕션: 404 반환
- 개발 환경: 기존 동작 유지

## Test plan

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npx vitest run\` 33건 통과
- [ ] 배포 후 프로덕션에서 해당 엔드포인트 404 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)