### PR TITLE
chore(deploy): 앱 리스너를 루프백으로 제한

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -7,7 +7,7 @@ module.exports = {
       env: {
         NODE_ENV: "production",
         PORT: 3000,
-        HOSTNAME: "0.0.0.0",
+        HOSTNAME: "127.0.0.1",
       },
       max_memory_restart: "500M",
       error_file: "./logs/error.log",


### PR DESCRIPTION
## Summary

- \`ecosystem.config.cjs\`의 \`HOSTNAME\`을 \`0.0.0.0\` → \`127.0.0.1\`로 변경
- Caddy 리버스 프록시(\`localhost:3000\`)만 접근 가능하도록 정리
- Caddy 설정은 이미 \`localhost:3000\`을 가리키고 있어 사용자 동작 변화 없음

## Follow-up (머지 후 수동)

- [ ] 서버에 배포 후 외부에서 \`:3000\` 직접 접근 거부되는지 확인
- [ ] 방화벽/보안 규칙에서 \`:3000\` 외부 허용 규칙 제거 (iptables 등)
- [ ] Caddy 경유 \`https://ship.leecommit.kr\` 정상 동작 확인

## Test plan

- [x] 구성 파일 변경만 (빌드/테스트 무관)
- [ ] 배포 후 End-to-end 확인 (Follow-up 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)