### PR TITLE
chore(auth): 세션 유효기간 7일로 조정

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,8 +15,8 @@ const SECRET = new TextEncoder().encode(authSecret);
 
 export const COOKIE_NAME = "smart-ship-session";
 
-/** 세션 최대 유지 시간: 30일 (초 단위) */
-export const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
+/** 세션 최대 유지 시간: 7일 (초 단위) */
+export const SESSION_MAX_AGE = 7 * 24 * 60 * 60;
 
 /** JWT 세션 토큰 생성 */
 export async function createSessionToken(username: string): Promise<string> {


### PR DESCRIPTION
## Summary

- \`SESSION_MAX_AGE\` 30일 → 7일

## Test plan

- [x] \`npx tsc --noEmit\` 통과
- [x] \`npx vitest run\` 통과
- [ ] 배포 후 로그인 후 쿠키 만료시간 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)