### PR TITLE
chore(auth): 세션 쿠키 SameSite 정책 강화

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    sameSite: "strict",
     maxAge: SESSION_MAX_AGE,
     path: "/",
   });

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -8,7 +8,7 @@ export async function POST() {
   response.cookies.set(COOKIE_NAME, "", {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
+    sameSite: "strict",
     maxAge: 0,
     path: "/",
   });


### PR DESCRIPTION
## Summary
- 로그인/로그아웃 응답 쿠키의 `sameSite` 옵션을 `lax` → `strict`로 상향
- 동일 출처에서만 세션 쿠키 전송 (CSRF 표면 축소)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 43개 테스트 통과
- [ ] 배포 후 로그인 → 대시보드 정상 진입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)