### PR TITLE
chore(log): 운영 로그 식별자 마스킹 유틸 도입

### DIFF
--- a/src/app/api/internal/tracking/route.ts
+++ b/src/app/api/internal/tracking/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { verifyInternalApiKey } from "@/lib/internal-auth";
+import { maskId } from "@/lib/log-mask";
 import {
   addBookingLogByOrderId,
   updateTrackingNumbers,
@@ -43,7 +44,7 @@ export async function POST(request: NextRequest) {
       );
       updated++;
       console.log(
-        `[internal/tracking] ${item.orderId}: 운송장 ${item.trackingNumber}`
+        `[internal/tracking] ${maskId(item.orderId)}: 운송장 ${maskId(item.trackingNumber)}`
       );
     }
 

--- a/src/lib/dispatch-worker.ts
+++ b/src/lib/dispatch-worker.ts
@@ -1,4 +1,5 @@
 import { scrapeTrackingNumbers } from "@/lib/gs-delivery/scrape-tracking";
+import { maskId } from "@/lib/log-mask";
 import { dispatchOrders, DELIVERY_COMPANY_CODES } from "@/lib/naver/dispatch";
 import { fetchDeliveryStatuses } from "@/lib/naver/orders";
 import {
@@ -110,7 +111,7 @@ export async function checkAndDispatch(): Promise<CheckAndDispatchResult> {
             );
             result.tracked++;
             console.log(
-              `[dispatch-worker] 운송장 감지 — 주문: ${group.orderId}, 운송장: ${tr.trackingNo}`
+              `[dispatch-worker] 운송장 감지 — 주문: ${maskId(group.orderId)}, 운송장: ${maskId(tr.trackingNo)}`
             );
           }
         } catch (err) {
@@ -153,7 +154,7 @@ export async function checkAndDispatch(): Promise<CheckAndDispatchResult> {
               );
               result.dispatched++;
               console.log(
-                `[dispatch-worker] ✅ 발송처리 완료 — 주문: ${group.orderId}`
+                `[dispatch-worker] ✅ 발송처리 완료 — 주문: ${maskId(group.orderId)}`
               );
             } else {
               updateDispatchStatus(group.orderId, "dispatch_failed");
@@ -165,7 +166,7 @@ export async function checkAndDispatch(): Promise<CheckAndDispatchResult> {
               );
               result.errors.push(`${group.orderId}: ${errMsg}`);
               console.error(
-                `[dispatch-worker] ❌ 발송처리 실패 — ${group.orderId}: ${errMsg}`
+                `[dispatch-worker] ❌ 발송처리 실패 — ${maskId(group.orderId)}: ${errMsg}`
               );
             }
           } catch (err) {
@@ -173,7 +174,7 @@ export async function checkAndDispatch(): Promise<CheckAndDispatchResult> {
               err instanceof Error ? err.message : "알 수 없는 오류";
             result.errors.push(`${group.orderId}: ${msg}`);
             console.error(
-              `[dispatch-worker] ❌ 예외 — ${group.orderId}: ${msg}`
+              `[dispatch-worker] ❌ 예외 — ${maskId(group.orderId)}: ${msg}`
             );
           }
         }
@@ -196,7 +197,7 @@ export async function checkAndDispatch(): Promise<CheckAndDispatchResult> {
               info.pickupDate
             );
             console.log(
-              `[dispatch-worker] 📦 ${info.status === "delivering" ? "집화 확인" : "배송 완료"} — 주문: ${order.orderId}`
+              `[dispatch-worker] 📦 ${info.status === "delivering" ? "집화 확인" : "배송 완료"} — 주문: ${maskId(order.orderId)}`
             );
           }
         }

--- a/src/lib/gs-delivery/scrape-tracking.ts
+++ b/src/lib/gs-delivery/scrape-tracking.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import path from "path";
 
+import { maskId } from "@/lib/log-mask";
+
 import { GS_URLS } from "./selectors";
 
 export interface ReservationInfo {
@@ -120,7 +122,7 @@ export async function scrapeTrackingNumbers(
     if (originalNo) {
       results.push({ reservationNo: originalNo, trackingNo });
       console.log(
-        `[scrape-tracking] ✅ 매칭: ${originalNo} → ${trackingNo ?? "미배정"}`
+        `[scrape-tracking] ✅ 매칭: ${maskId(originalNo)} → ${trackingNo ? maskId(trackingNo) : "미배정"}`
       );
     }
   }

--- a/src/lib/log-mask.test.ts
+++ b/src/lib/log-mask.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { maskId, maskName, maskPhone } from "./log-mask";
+
+describe("log-mask (production)", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("maskId: 9자 이상은 앞 4 + *** + 뒤 4", () => {
+    expect(maskId("2024020112345678")).toBe("2024***5678");
+    expect(maskId("123456789")).toBe("1234***6789");
+  });
+
+  it("maskId: 짧은 ID는 첫/끝 글자만 노출", () => {
+    expect(maskId("abc12345")).toBe("a******5");
+    expect(maskId("abc")).toBe("a*c");
+    expect(maskId("ab")).toBe("**");
+    expect(maskId("a")).toBe("*");
+  });
+
+  it("maskId: 빈 값 처리", () => {
+    expect(maskId(null)).toBe("");
+    expect(maskId(undefined)).toBe("");
+    expect(maskId("")).toBe("");
+  });
+
+  it("maskName: 첫 글자만 노출", () => {
+    expect(maskName("홍길동")).toBe("홍**");
+    expect(maskName("김")).toBe("김");
+    expect(maskName("Alice")).toBe("A****");
+  });
+
+  it("maskPhone: 가운데 자리 마스킹", () => {
+    expect(maskPhone("010-1234-5678")).toBe("010-****-5678");
+    expect(maskPhone("01012345678")).toBe("010-****-5678");
+    expect(maskPhone("010 1234 5678")).toBe("010-****-5678");
+  });
+});
+
+describe("log-mask (development)", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("개발 환경에서는 원본 그대로 반환", () => {
+    expect(maskId("2024020112345678")).toBe("2024020112345678");
+    expect(maskName("홍길동")).toBe("홍길동");
+    expect(maskPhone("010-1234-5678")).toBe("010-1234-5678");
+  });
+});

--- a/src/lib/log-mask.ts
+++ b/src/lib/log-mask.ts
@@ -1,0 +1,41 @@
+/**
+ * 로그 출력 시 민감 식별자를 마스킹.
+ * 프로덕션에서만 마스킹하고, 개발 환경에서는 원본을 그대로 반환한다.
+ */
+
+function isProd(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+/**
+ * 주문번호/예약번호 등 ID 마스킹.
+ * 앞 4자리와 끝 4자리만 노출하고 가운데를 `***`로 가린다.
+ * 길이가 9자 미만이면 가운데 한 글자만 노출.
+ */
+export function maskId(id: string | null | undefined): string {
+  if (!id) return "";
+  if (!isProd()) return id;
+  if (id.length <= 8) {
+    if (id.length <= 2) return "*".repeat(id.length);
+    return `${id.slice(0, 1)}${"*".repeat(id.length - 2)}${id.slice(-1)}`;
+  }
+  return `${id.slice(0, 4)}***${id.slice(-4)}`;
+}
+
+/** 이름 마스킹: 첫 글자만 노출, 나머지는 `*` */
+export function maskName(name: string | null | undefined): string {
+  if (!name) return "";
+  if (!isProd()) return name;
+  if (name.length <= 1) return name;
+  return `${name.slice(0, 1)}${"*".repeat(name.length - 1)}`;
+}
+
+/** 전화번호 마스킹: 가운데 4자리만 가림 (010-****-5678) */
+export function maskPhone(phone: string | null | undefined): string {
+  if (!phone) return "";
+  if (!isProd()) return phone;
+  return phone.replace(
+    /(\d{2,3})[\s-]?\d{3,4}[\s-]?(\d{4})/,
+    "$1-****-$2"
+  );
+}

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, gte, inArray } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { bookingLogs, orders } from "@/lib/db/schema";
+import { maskId } from "@/lib/log-mask";
 
 import type { BookingLogEntry, DeliveryTrackingStatus, DeliveryType, DispatchStatus, OrderStatus } from "@/types";
 
@@ -334,7 +335,7 @@ export function upsertOrdersFromLocal(
   }
 
   console.log(
-    `[orders] upsert 완료: ${orderId} — 기존 ${existingProductOrderIds.size}건, 신규 ${orderItems.length - existingProductOrderIds.size}건`
+    `[orders] upsert 완료: ${maskId(orderId)} — 기존 ${existingProductOrderIds.size}건, 신규 ${orderItems.length - existingProductOrderIds.size}건`
   );
 }
 


### PR DESCRIPTION
## Summary
- `src/lib/log-mask.ts` 추가: `maskId`, `maskName`, `maskPhone` 헬퍼
- 마스킹 규칙: 앞 4자 + `***` + 뒤 4자 (9자 미만은 첫/끝 한 글자만 노출)
- 개발 환경(`NODE_ENV !== "production"`)에서는 원본 반환 → 디버깅 용이성 유지
- 적용 위치: dispatch-worker, internal/tracking, scrape-tracking, orders.upsert
- 단위 테스트 6건 (production/development 분기 포함)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 49개 테스트 통과 (신규 6 + 기존 43)
- [ ] 배포 후 PM2 로그에 `2024***5678` 형태로 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)