### PR TITLE
fix(naver): 배송지 없는 주문으로 인한 주문 동기화 실패 방지

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
       name: "smart-ship",
       script: ".next/standalone/server.js",
       cwd: "/home/ubuntu/smart-ship-automation",
+      node_args: "--env-file=.env.local",
       env: {
         NODE_ENV: "production",
         PORT: 3000,

--- a/src/lib/naver/orders.ts
+++ b/src/lib/naver/orders.ts
@@ -82,10 +82,18 @@ async function fetchOrdersForWindow(
     }
 
     const parsed = conditionalOrdersResponseSchema.parse(json);
-    const orders = parsed.data.contents.map((c) =>
-      toProductOrderDetail(c.content),
-    );
-    results.push(...orders);
+    const mapped = parsed.data.contents
+      .map((c) => toProductOrderDetail(c.content))
+      .filter((o): o is ProductOrderDetail => o !== null);
+
+    const skippedInPage = parsed.data.contents.length - mapped.length;
+    if (skippedInPage > 0) {
+      console.warn(
+        `[naver/orders] 배송지 없는 주문 ${skippedInPage}건 스킵 (page=${page})`,
+      );
+    }
+
+    results.push(...mapped);
 
     hasNext = parsed.data.pagination.hasNext;
     page++;

--- a/src/lib/naver/types.ts
+++ b/src/lib/naver/types.ts
@@ -32,13 +32,15 @@ export const conditionalOrderContentSchema = z.object({
     optionCode: z.string().optional(),
     placeOrderStatus: z.string(),
     shippingMemo: z.string().optional(),
-    shippingAddress: z.object({
-      name: z.string(),
-      tel1: z.string(),
-      baseAddress: z.string(),
-      detailedAddress: z.string().optional(),
-      zipCode: z.string(),
-    }),
+    shippingAddress: z
+      .object({
+        name: z.string(),
+        tel1: z.string(),
+        baseAddress: z.string(),
+        detailedAddress: z.string().optional(),
+        zipCode: z.string(),
+      })
+      .optional(),
   }),
 });
 
@@ -84,8 +86,14 @@ export interface ProductOrderDetail {
   };
 }
 
-/** 조건형 API 응답 → ProductOrderDetail 변환 */
-export function toProductOrderDetail(raw: ConditionalOrderContent): ProductOrderDetail {
+/**
+ * 조건형 API 응답 → ProductOrderDetail 변환.
+ * 배송지가 없는 주문(디지털 상품 등)은 택배 자동화 대상이 아니므로 null 반환.
+ */
+export function toProductOrderDetail(raw: ConditionalOrderContent): ProductOrderDetail | null {
+  const addr = raw.productOrder.shippingAddress;
+  if (!addr) return null;
+
   return {
     productOrderId: raw.productOrder.productOrderId,
     orderId: raw.order.orderId,
@@ -97,11 +105,11 @@ export function toProductOrderDetail(raw: ConditionalOrderContent): ProductOrder
     placeOrderStatus: raw.productOrder.placeOrderStatus,
     shippingMemo: raw.productOrder.shippingMemo ?? null,
     shippingAddress: {
-      name: raw.productOrder.shippingAddress.name,
-      tel1: raw.productOrder.shippingAddress.tel1,
-      baseAddress: raw.productOrder.shippingAddress.baseAddress,
-      detailedAddress: raw.productOrder.shippingAddress.detailedAddress ?? null,
-      zipCode: raw.productOrder.shippingAddress.zipCode,
+      name: addr.name,
+      tel1: addr.tel1,
+      baseAddress: addr.baseAddress,
+      detailedAddress: addr.detailedAddress ?? null,
+      zipCode: addr.zipCode,
     },
   };
 }


### PR DESCRIPTION
## Summary
- 조건형 주문 조회 응답에 `shippingAddress`가 없는 주문이 섞이면 zod 검증이 실패해 전체 동기화가 500으로 중단되는 문제를 수정
- 배송지 없는 주문은 택배 자동화 대상이 아니므로 스킵 + 경고 로그로 처리
- PM2 ecosystem에서 `.env.local` 로딩 경로를 `--env-file`로 명시

## Changes
- `src/lib/naver/types.ts` — `shippingAddress` optional 처리, `toProductOrderDetail`가 주소 없는 주문에 대해 null 반환
- `src/lib/naver/orders.ts` — null 필터링 + 스킵 건수 경고 로그
- `ecosystem.config.cjs` — `node_args: "--env-file=.env.local"` 추가

## Test plan
- [ ] 서버 배포 후 `/api/orders/sync` 호출 시 200 응답
- [ ] 정상 주문은 DB에 upsert 되는지 확인
- [ ] 배송지 없는 주문이 있으면 PM2 로그에 `[naver/orders] 배송지 없는 주문 N건 스킵` 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)