### PR TITLE
docs(claude-md): 배포 명령 placeholder 형식으로 통일

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,8 @@ npm run dev
 
 ### 서버 배포
 ```bash
-ssh -i ~/.ssh/slack-ai-agents.key ubuntu@140.245.69.231 \
+# 호스트/키는 ~/.ssh/config 또는 로컬 환경에서 관리
+ssh <server> \
   "cd smart-ship-automation && git pull && npm run build && pm2 restart smart-ship"
 ```
 


### PR DESCRIPTION
## 관련 이슈
Closes #53

## 변경 내용
- `CLAUDE.md` 서버 배포 섹션 — `ssh` 명령을 placeholder 기반으로 재작성
- 호스트/키 경로는 `~/.ssh/config` 또는 로컬 환경에서 관리

## 기대 효과
- 문서가 환경 독립적
- 환경 변경 시 문서 동시 수정 불필요

## 테스트
- [x] CLAUDE.md 변경 외 동작 영향 없음