### PR TITLE
fix(gs-delivery): Playwright 브라우저 idle 시 메모리 누수

### DIFF
--- a/.claude/plans/51-browser-idle-cleanup.md
+++ b/.claude/plans/51-browser-idle-cleanup.md
@@ -1,0 +1,357 @@
+# fix(gs-delivery): Playwright 브라우저 idle 시 메모리 누수
+
+## 이슈
+- 번호: #51
+- 브랜치: `fix/51-browser-idle-cleanup`
+
+## 개요
+GS택배 예약 작업 완료 후 Playwright Chromium 인스턴스가 정리되지 않아 메모리에 잔존. idle 타임아웃 자동 종료 + visit-pickup 페이지 close 이벤트 + graceful shutdown 3가지 안전장치로 정상 경로 + 사용자 정리 + 프로세스 종료 모두 커버.
+
+## 원인 분석
+
+### Browser 인스턴스 lifecycle 현황
+
+`src/lib/gs-delivery/browser.ts`에서 module-level singleton으로 `browser`/`context`를 관리.
+
+| `closeBrowser()` 호출 케이스 | 호출 안 되는 케이스 |
+|---|---|
+| 브라우저 크래시 + 예외 (`worker.ts:75`) | **예약 성공 시** (`worker.ts:155` return) |
+| `cancelBooking()` 명시 호출 (`worker.ts:230`) | **재시도 다 실패 시** (`worker.ts:180` 이후) |
+| visit-pickup 실패 시 (`worker.ts:293`) | **visit-pickup 성공 후** (`worker.ts:280` 의도적 page 유지) |
+
+→ 거의 모든 정상 경로에서 `closeBrowser()` 미호출. chromium 프로세스가 메모리에 영구 잔존.
+
+### 부가 문제: visit-pickup의 page close 미감지
+
+visit-pickup은 의도적으로 page를 안 닫음 (사용자가 직접 예약하라고). 사용자가 브라우저 창을 닫아도 worker가 이를 감지하지 못해 browser/context 정리 안 됨.
+
+### 부가 문제: graceful shutdown 부재
+
+`SIGINT`/`SIGTERM` 핸들러 없음. `next dev` 종료(Ctrl+C) 시 chromium이 좀비로 남을 수 있음 (Playwright가 보통 잘 정리하지만 보장 없음).
+
+## 변경 파일 목록
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `src/lib/gs-delivery/browser.ts` | 수정 | idle 타임아웃 메커니즘 추가 (`scheduleIdleShutdown` / `cancelIdleShutdown`) |
+| `src/lib/gs-delivery/worker.ts` | 수정 | 작업 enqueue 시 idle timer 취소, 큐 비면 idle timer 시작, visit-pickup 성공 시 page close 핸들러 |
+| `src/instrumentation.ts` | 수정 | SIGINT/SIGTERM 핸들러 추가 (graceful shutdown) |
+
+## 구현 상세
+
+### 1. browser.ts — idle 타임아웃 메커니즘
+
+**Before:** (현재)
+```typescript
+let browser: Browser | null = null;
+let context: BrowserContext | null = null;
+
+// ... getBrowser / getContext / newPage / saveCookies / restoreCookies ...
+
+export async function closeBrowser(): Promise<void> {
+  await saveCookies();
+  if (context) {
+    await context.close().catch(() => {});
+    context = null;
+  }
+  if (browser) {
+    await browser.close().catch(() => {});
+    browser = null;
+  }
+}
+```
+
+**After:**
+```typescript
+let browser: Browser | null = null;
+let context: BrowserContext | null = null;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Idle 타임아웃 — 큐 비고 N분간 신규 작업 없으면 브라우저 자동 종료 */
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5분
+
+// ... getBrowser / getContext / newPage / saveCookies / restoreCookies ...
+
+/**
+ * Idle 종료 타이머 시작. 이미 예약된 타이머가 있으면 재설정.
+ * worker.ts에서 큐 처리 완료 시 호출.
+ */
+export function scheduleIdleShutdown(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    idleTimer = null;
+    console.log(`[browser] ${IDLE_TIMEOUT_MS / 1000 / 60}분간 idle — 자동 종료`);
+    void closeBrowser();
+  }, IDLE_TIMEOUT_MS);
+}
+
+/**
+ * Idle 종료 타이머 취소.
+ * worker.ts에서 신규 작업 enqueue 시 호출.
+ */
+export function cancelIdleShutdown(): void {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+}
+
+export async function closeBrowser(): Promise<void> {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+  await saveCookies();
+  if (context) {
+    await context.close().catch(() => {});
+    context = null;
+  }
+  if (browser) {
+    await browser.close().catch(() => {});
+    browser = null;
+  }
+}
+```
+
+**설명:**
+- `idleTimer`도 module-level로 관리. 작업 들어오면 cancel, 큐 비면 schedule.
+- `closeBrowser()` 시작에서 timer 정리 — 외부에서 명시 종료할 때 잔여 timer 방지.
+- 5분 idle 후 자동 종료. 사용자의 "택배 예약할 때만 켜는" 운영 패턴에 맞음 (예약 burst → idle → 자동 정리).
+- 쿠키는 파일로 영속화되므로 다음 작업 시 재로그인 불필요.
+
+### 2. worker.ts — idle 타이머 통합
+
+**Before:** (현재 `enqueueBookings`)
+```typescript
+export function enqueueBookings(tasks: BookingTask[]): void {
+  initOnce();
+  queue.push(...tasks);
+  processNext();
+}
+```
+
+**After:**
+```typescript
+import { cancelIdleShutdown, closeBrowser, newPage, scheduleIdleShutdown } from "./browser";
+// ... 기존 import ...
+
+export function enqueueBookings(tasks: BookingTask[]): void {
+  initOnce();
+  cancelIdleShutdown(); // 신규 작업 들어오면 idle 타이머 취소
+  queue.push(...tasks);
+  processNext();
+}
+```
+
+**Before:** (현재 `processNext` finally 블록)
+```typescript
+} finally {
+  isProcessing = false;
+
+  if (browserCrashed) {
+    drainQueue();
+    cancelRequested = false;
+  } else if (queue.length === 0) {
+    // 큐 처리 완료 — 동기화 누락된 booked 주문 재전송
+    void resyncBookedOrders();
+  } else {
+    processNext();
+  }
+}
+```
+
+**After:**
+```typescript
+} finally {
+  isProcessing = false;
+
+  if (browserCrashed) {
+    drainQueue();
+    cancelRequested = false;
+  } else if (queue.length === 0) {
+    // 큐 처리 완료 — 동기화 누락된 booked 주문 재전송
+    void resyncBookedOrders();
+    scheduleIdleShutdown(); // 큐 비면 5분 후 자동 종료
+  } else {
+    processNext();
+  }
+}
+```
+
+**Before:** (현재 `enqueueVisitPickup` 시작 부분 + 성공 분기)
+```typescript
+export async function enqueueVisitPickup(task: VisitPickupTask): Promise<void> {
+  initOnce();
+
+  const logId = task.allOrderDbIds[0];
+  // ... 로그 ...
+
+  const page = await newPage();
+  try {
+    // ... 로그인, 폼 자동화 ...
+
+    if (result.success) {
+      addBookingLog(
+        logId,
+        "complete",
+        `방문택배 폼 입력 완료: ${task.recipients.length}명 수령인 — 브라우저에서 예약하기를 클릭해주세요`
+      );
+      console.log(/* ... */);
+      // 페이지를 닫지 않음 — 사용자가 직접 확인하고 예약
+    } else {
+      // ...
+    }
+  } catch (error) {
+    // ...
+  }
+}
+```
+
+**After:**
+```typescript
+export async function enqueueVisitPickup(task: VisitPickupTask): Promise<void> {
+  initOnce();
+  cancelIdleShutdown(); // 신규 작업 시작 — idle 타이머 취소
+
+  const logId = task.allOrderDbIds[0];
+  // ... 로그 ...
+
+  const page = await newPage();
+  try {
+    // ... 로그인, 폼 자동화 ...
+
+    if (result.success) {
+      addBookingLog(
+        logId,
+        "complete",
+        `방문택배 폼 입력 완료: ${task.recipients.length}명 수령인 — 브라우저에서 예약하기를 클릭해주세요`
+      );
+      console.log(/* ... */);
+      // 페이지를 닫지 않음 — 사용자가 직접 확인하고 예약.
+      // 단, 사용자가 페이지 닫으면 브라우저도 정리한다.
+      page.once("close", () => {
+        console.log("[worker] 방문택배 페이지 종료 감지 — 브라우저 정리");
+        void closeBrowser();
+      });
+    } else {
+      // ...
+    }
+  } catch (error) {
+    // ...
+  }
+}
+```
+
+**설명:**
+- `enqueueBookings`/`enqueueVisitPickup` 시작 시 `cancelIdleShutdown()` — 작업 burst 중에 timer가 firing되는 것 방지.
+- 큐 비면 `scheduleIdleShutdown()` — 5분 후 자동 정리.
+- visit-pickup 성공 후 page에 `close` 이벤트 리스너 — 사용자가 창 닫으면 즉시 `closeBrowser()`. 5분 기다릴 필요 없음.
+- `page.once("close")`: 한 번만 발화 (보호 차원).
+
+### 3. instrumentation.ts — graceful shutdown
+
+**Before:** (현재)
+```typescript
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  if (process.env.DEPLOY_MODE !== "server") return;
+
+  const { startDispatchPolling } = await import("@/lib/dispatch-worker");
+  startDispatchPolling();
+  console.log("[instrumentation] 서버 모드 — 발송처리 폴링 자동 시작");
+}
+```
+
+**After:**
+```typescript
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // 서버 모드 — 발송처리 폴링 자동 시작
+  if (process.env.DEPLOY_MODE === "server") {
+    const { startDispatchPolling } = await import("@/lib/dispatch-worker");
+    startDispatchPolling();
+    console.log("[instrumentation] 서버 모드 — 발송처리 폴링 자동 시작");
+  }
+
+  // 종료 시그널 시 브라우저 정리 (좀비 chromium 방지)
+  registerShutdownHandlers();
+}
+
+let shutdownRegistered = false;
+
+function registerShutdownHandlers(): void {
+  if (shutdownRegistered) return;
+  shutdownRegistered = true;
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    console.log(`[instrumentation] ${signal} 수신 — graceful shutdown`);
+    try {
+      const { closeBrowser } = await import("@/lib/gs-delivery/browser");
+      await closeBrowser();
+    } catch (err) {
+      console.error("[instrumentation] 브라우저 정리 실패:", err);
+    }
+    process.exit(0);
+  };
+
+  process.once("SIGINT", () => void shutdown("SIGINT"));
+  process.once("SIGTERM", () => void shutdown("SIGTERM"));
+}
+```
+
+**설명:**
+- 서버/로컬 모두 적용 (서버는 dispatch-worker가 띄우는 브라우저, 로컬은 worker.ts 브라우저).
+- `once`로 등록 — 중복 등록 방지 (Next.js HMR 환경에서 instrumentation이 여러 번 호출될 수 있음).
+- `shutdownRegistered` 플래그도 같은 목적의 보호 장치.
+- `process.exit(0)` 전에 브라우저 정리 완료 보장.
+
+## ADR 작성 (해당 시)
+
+**대상 여부**: **NO**
+
+**판단 근거**:
+- 되돌리기 어렵나? — 아님. 단일 모듈(gs-delivery/browser) lifecycle 정책 변경. 롤백 쉬움.
+- 대안이 있었나? — 있음 (매 작업 후 즉시 종료 / 영구 유지). 하지만 트레이드오프가 명확하고 비자명하지 않음 (idle timeout이 일반적 패턴).
+- 장기 영향? — 메모리/성능에 영향은 있으나, 6개월 뒤 재참조할 만한 판단은 아님.
+- 비자명? — `IDLE_TIMEOUT_MS = 5분` 상수 옆 주석으로 충분.
+
+→ 버그 수정 + 표준적인 idle timeout 패턴 적용이라 ADR 인프라(`docs/adr/`) 없는 현 상황에서도 ADR 대상 아님.
+
+(참고: 현재 프로젝트에 `docs/adr/` 디렉토리 자체가 없음. ADR 인프라 도입은 별건으로 `/init-project` 영역.)
+
+## 커밋 계획
+
+1. `fix(gs-delivery): browser idle timeout 자동 종료 메커니즘 추가`
+   - `src/lib/gs-delivery/browser.ts` — `scheduleIdleShutdown` / `cancelIdleShutdown` 추가, `closeBrowser`에서 timer 정리
+   - `src/lib/gs-delivery/worker.ts` — `enqueueBookings`/`enqueueVisitPickup` 시작 시 cancel, 큐 비면 schedule
+
+2. `fix(gs-delivery): visit-pickup 페이지 종료 시 브라우저 자동 정리`
+   - `src/lib/gs-delivery/worker.ts` — visit-pickup 성공 시 `page.once("close")` 핸들러로 `closeBrowser()` 호출
+
+3. `feat(gs-delivery): SIGINT/SIGTERM graceful shutdown 추가`
+   - `src/instrumentation.ts` — 종료 시그널 핸들러로 `closeBrowser()` 호출
+
+## 테스트 계획
+
+수동 테스트 (Playwright 자동화 E2E라 unit test 불가):
+
+- [ ] **Idle 타임아웃 정상 동작**
+  - 택배 예약 1건 처리 → 큐 비고 5분 대기 → 로그에 "5분간 idle — 자동 종료" 출력 확인
+  - chromium 프로세스가 종료되었는지 macOS에서 확인 (Activity Monitor)
+- [ ] **신규 작업 시 timer 취소**
+  - 작업 처리 후 3분 대기 → 신규 작업 enqueue → idle timer가 취소되고 작업 처리됨 확인
+- [ ] **visit-pickup page close 감지**
+  - visit-pickup 폼 입력 후 사용자가 브라우저 창 닫기 → 로그에 "방문택배 페이지 종료 감지" 출력 + 브라우저 정리 확인
+- [ ] **Graceful shutdown**
+  - `next dev` 실행 중 Ctrl+C → 로그에 "SIGINT 수신 — graceful shutdown" 출력 + chromium 좀비 없는지 확인
+- [ ] **쿠키 영속화**
+  - idle 자동 종료 후 신규 작업 시 재로그인 없이 진행되는지 (쿠키 파일 유효 시간 내) 확인
+
+## 체크리스트
+
+- [ ] 프로젝트 컨벤션 규칙 준수 (네이밍, 커밋 메시지, import 정렬)
+- [ ] 민감 정보 하드코딩 없음
+- [ ] 타입 안전성 확인 (`any` 미사용, strict 모드)
+- [ ] 에러 핸들링 포함 (`closeBrowser` 실패 시 catch)
+- [ ] ADR 작성 필요 여부 판단 완료 (대상 아님 판정)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,13 +1,37 @@
 /**
  * Next.js instrumentation hook — 서버 프로세스 시작 시 1회 호출.
- * DEPLOY_MODE=server일 때만 발송처리 자동 폴링을 시작한다.
- * 로컬(DEPLOY_MODE=local 또는 미설정) 에서는 폴링을 시작하지 않는다.
+ * - DEPLOY_MODE=server 이면 발송처리 자동 폴링을 시작한다.
+ * - 종료 시그널(SIGINT/SIGTERM) 수신 시 Playwright 브라우저를 정리한다 (좀비 chromium 방지).
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
-  if (process.env.DEPLOY_MODE !== "server") return;
 
-  const { startDispatchPolling } = await import("@/lib/dispatch-worker");
-  startDispatchPolling();
-  console.log("[instrumentation] 서버 모드 — 발송처리 폴링 자동 시작");
+  if (process.env.DEPLOY_MODE === "server") {
+    const { startDispatchPolling } = await import("@/lib/dispatch-worker");
+    startDispatchPolling();
+    console.log("[instrumentation] 서버 모드 — 발송처리 폴링 자동 시작");
+  }
+
+  registerShutdownHandlers();
+}
+
+let shutdownRegistered = false;
+
+function registerShutdownHandlers(): void {
+  if (shutdownRegistered) return;
+  shutdownRegistered = true;
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    console.log(`[instrumentation] ${signal} 수신 — graceful shutdown`);
+    try {
+      const { closeBrowser } = await import("@/lib/gs-delivery/browser");
+      await closeBrowser();
+    } catch (err) {
+      console.error("[instrumentation] 브라우저 정리 실패:", err);
+    }
+    process.exit(0);
+  };
+
+  process.once("SIGINT", () => void shutdown("SIGINT"));
+  process.once("SIGTERM", () => void shutdown("SIGTERM"));
 }

--- a/src/lib/gs-delivery/browser.ts
+++ b/src/lib/gs-delivery/browser.ts
@@ -7,9 +7,13 @@ import type { Browser, BrowserContext, Page } from "playwright";
 
 let browser: Browser | null = null;
 let context: BrowserContext | null = null;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** 쿠키 저장 경로 — 로그인 세션 재사용용 */
 const COOKIES_PATH = path.join(process.cwd(), "data", "cookies.json");
+
+/** Idle 타임아웃 — 큐 비고 N분간 신규 작업 없으면 브라우저 자동 종료 */
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** 서버 모드 여부 — DEPLOY_MODE=server 이면 headless */
 const isServerMode = () => process.env.DEPLOY_MODE === "server";
@@ -100,8 +104,38 @@ async function restoreCookies(ctx: BrowserContext): Promise<void> {
   }
 }
 
+/**
+ * Idle 종료 타이머 시작. 이미 예약된 타이머가 있으면 재설정.
+ * worker.ts에서 큐 처리 완료 시 호출.
+ */
+export function scheduleIdleShutdown(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    idleTimer = null;
+    console.log(
+      `[browser] ${IDLE_TIMEOUT_MS / 1000 / 60}분간 idle — 자동 종료`,
+    );
+    void closeBrowser();
+  }, IDLE_TIMEOUT_MS);
+}
+
+/**
+ * Idle 종료 타이머 취소.
+ * worker.ts에서 신규 작업 enqueue 시 호출.
+ */
+export function cancelIdleShutdown(): void {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+}
+
 /** 브라우저 + 컨텍스트 전체 정리 (쿠키 저장 후 종료) */
 export async function closeBrowser(): Promise<void> {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
   await saveCookies();
   if (context) {
     await context.close().catch(() => {});

--- a/src/lib/gs-delivery/worker.ts
+++ b/src/lib/gs-delivery/worker.ts
@@ -1,4 +1,9 @@
-import { closeBrowser, newPage } from "./browser";
+import {
+  cancelIdleShutdown,
+  closeBrowser,
+  newPage,
+  scheduleIdleShutdown,
+} from "./browser";
 import { ensureLoggedIn, LoginError } from "./auth";
 import { bookDomestic, bookNextDay } from "./automation";
 import { bookVisitPickup } from "./visit-pickup";
@@ -29,7 +34,7 @@ function initOnce(): void {
   const recovered = recoverStuckBookings();
   if (recovered > 0) {
     console.log(
-      `[worker] ${recovered}건의 중단된 예약을 pending으로 복구했습니다.`
+      `[worker] ${recovered}건의 중단된 예약을 pending으로 복구했습니다.`,
     );
   }
 }
@@ -39,6 +44,7 @@ function initOnce(): void {
  */
 export function enqueueBookings(tasks: BookingTask[]): void {
   initOnce();
+  cancelIdleShutdown();
   queue.push(...tasks);
   processNext();
 }
@@ -64,12 +70,16 @@ async function processNext(): Promise<void> {
       // 취소 요청: 현재 건을 pending으로 복구 (failed 아님)
       updateOrderStatusBatch(task.orderDbIds, "pending");
       addBookingLog(task.orderDbIds[0], "info", "사용자가 예약을 취소했습니다");
-      console.log(`[worker] 예약 취소 — 주문: ${task.naverOrderId} → pending 복구`);
+      console.log(
+        `[worker] 예약 취소 — 주문: ${task.naverOrderId} → pending 복구`,
+      );
     } else {
       // 일반 크래시: 기존 동작 (failed 처리)
       updateOrderStatusBatch(task.orderDbIds, "failed", msg);
       addBookingLog(task.orderDbIds[0], "error", `예상치 못한 실패: ${msg}`);
-      console.error(`[worker] ❌ 예약 실패 — 주문: ${task.naverOrderId}, 에러: ${msg}`);
+      console.error(
+        `[worker] ❌ 예약 실패 — 주문: ${task.naverOrderId}, 에러: ${msg}`,
+      );
     }
 
     await closeBrowser();
@@ -82,6 +92,7 @@ async function processNext(): Promise<void> {
     } else if (queue.length === 0) {
       // 큐 처리 완료 — 동기화 누락된 booked 주문 재전송
       void resyncBookedOrders();
+      scheduleIdleShutdown();
     } else {
       processNext();
     }
@@ -98,9 +109,13 @@ const RETRY_DELAYS = [2000, 4000]; // ms
 async function processSingleOrder(task: BookingTask): Promise<void> {
   const logId = task.orderDbIds[0]; // 로그는 첫 번째 DB row에 기록
 
-  addBookingLog(logId, "start", `예약 시작: ${task.recipientName} (${task.orderDbIds.length}개 상품)`);
+  addBookingLog(
+    logId,
+    "start",
+    `예약 시작: ${task.recipientName} (${task.orderDbIds.length}개 상품)`,
+  );
   console.log(
-    `[worker] 예약 시작 — 주문: ${task.naverOrderId}, 수령인: ${task.recipientName}, 상품 ${task.orderDbIds.length}개`
+    `[worker] 예약 시작 — 주문: ${task.naverOrderId}, 수령인: ${task.recipientName}, 상품 ${task.orderDbIds.length}개`,
   );
 
   let lastResult: Awaited<ReturnType<typeof bookDomestic>> | null = null;
@@ -108,7 +123,11 @@ async function processSingleOrder(task: BookingTask): Promise<void> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     if (attempt > 0) {
       const delay = RETRY_DELAYS[attempt - 1];
-      addBookingLog(logId, "retry", `재시도 ${attempt}/${MAX_RETRIES}회 (${delay / 1000}초 후)`);
+      addBookingLog(
+        logId,
+        "retry",
+        `재시도 ${attempt}/${MAX_RETRIES}회 (${delay / 1000}초 후)`,
+      );
       console.log(`[worker] 재시도 ${attempt}/${MAX_RETRIES} — ${delay}ms 후`);
       await new Promise((r) => setTimeout(r, delay));
     }
@@ -122,7 +141,7 @@ async function processSingleOrder(task: BookingTask): Promise<void> {
       }
 
       console.log(
-        `[worker] 폼 자동화 시작 — 유형: ${task.deliveryType === "nextDay" ? "내일배송" : "국내택배"}`
+        `[worker] 폼 자동화 시작 — 유형: ${task.deliveryType === "nextDay" ? "내일배송" : "국내택배"}`,
       );
       const result =
         task.deliveryType === "nextDay"
@@ -136,20 +155,22 @@ async function processSingleOrder(task: BookingTask): Promise<void> {
           task.orderDbIds,
           "booked",
           JSON.stringify({ reservationNo: result.reservationNo }),
-          result.reservationNo
+          result.reservationNo,
         );
         addBookingLog(
           logId,
           "complete",
-          `예약 완료${result.reservationNo ? `: ${result.reservationNo}` : ""}`
+          `예약 완료${result.reservationNo ? `: ${result.reservationNo}` : ""}`,
         );
         console.log(
-          `[worker] ✅ 예약 완료 — 주문: ${task.naverOrderId}, 예약번호: ${result.reservationNo ?? "(없음)"}`
+          `[worker] ✅ 예약 완료 — 주문: ${task.naverOrderId}, 예약번호: ${result.reservationNo ?? "(없음)"}`,
         );
         void syncBookingResult({
           orderId: task.naverOrderId,
           status: "booked",
-          bookingResult: JSON.stringify({ reservationNo: result.reservationNo }),
+          bookingResult: JSON.stringify({
+            reservationNo: result.reservationNo,
+          }),
           bookingReservationNo: result.reservationNo,
         });
         return;
@@ -180,13 +201,13 @@ async function processSingleOrder(task: BookingTask): Promise<void> {
   updateOrderStatusBatch(
     task.orderDbIds,
     "failed",
-    lastResult?.error ?? "알 수 없는 오류"
+    lastResult?.error ?? "알 수 없는 오류",
   );
   addBookingLog(
     logId,
     "error",
     `예약 실패 (${MAX_RETRIES + 1}회 시도): ${lastResult?.error}`,
-    lastResult?.screenshotPath
+    lastResult?.screenshotPath,
   );
   console.error(`[worker] ❌ 최종 실패 — 주문: ${task.naverOrderId}`);
   if (lastResult?.screenshotPath) {
@@ -206,7 +227,7 @@ function drainQueue(): void {
   if (queue.length === 0) return;
 
   console.warn(
-    `[worker] ⚠️ 실패로 인해 나머지 ${queue.length}건 처리 중단 — pending으로 복구`
+    `[worker] ⚠️ 실패로 인해 나머지 ${queue.length}건 처리 중단 — pending으로 복구`,
   );
 
   for (const remaining of queue) {
@@ -214,7 +235,7 @@ function drainQueue(): void {
     addBookingLog(
       remaining.orderDbIds[0],
       "info",
-      "이전 주문 실패로 처리 중단됨 — pending으로 복구"
+      "이전 주문 실패로 처리 중단됨 — pending으로 복구",
     );
   }
 
@@ -248,15 +269,16 @@ export function getWorkerStatus(): {
  */
 export async function enqueueVisitPickup(task: VisitPickupTask): Promise<void> {
   initOnce();
+  cancelIdleShutdown();
 
   const logId = task.allOrderDbIds[0];
   addBookingLog(
     logId,
     "start",
-    `방문택배 다량 접수 시작: ${task.recipients.length}명 수령인`
+    `방문택배 다량 접수 시작: ${task.recipients.length}명 수령인`,
   );
   console.log(
-    `[worker] 방문택배 시작 — ${task.recipients.length}명 수령인, ${task.allOrderDbIds.length}개 상품`
+    `[worker] 방문택배 시작 — ${task.recipients.length}명 수령인, ${task.allOrderDbIds.length}개 상품`,
   );
 
   const page = await newPage();
@@ -272,15 +294,20 @@ export async function enqueueVisitPickup(task: VisitPickupTask): Promise<void> {
       addBookingLog(
         logId,
         "complete",
-        `방문택배 폼 입력 완료: ${task.recipients.length}명 수령인 — 브라우저에서 예약하기를 클릭해주세요`
+        `방문택배 폼 입력 완료: ${task.recipients.length}명 수령인 — 브라우저에서 예약하기를 클릭해주세요`,
       );
       console.log(
-        `[worker] ✅ 방문택배 폼 입력 완료 — 브라우저에서 확인 후 예약하기를 클릭해주세요`
+        `[worker] ✅ 방문택배 폼 입력 완료 — 브라우저에서 확인 후 예약하기를 클릭해주세요`,
       );
       // 페이지를 닫지 않음 — 사용자가 직접 확인하고 예약
     } else {
       updateOrderStatusBatch(task.allOrderDbIds, "failed", result.error);
-      addBookingLog(logId, "error", `방문택배 실패: ${result.error}`, result.screenshotPath);
+      addBookingLog(
+        logId,
+        "error",
+        `방문택배 실패: ${result.error}`,
+        result.screenshotPath,
+      );
       console.error(`[worker] ❌ 방문택배 실패: ${result.error}`);
       await page.close().catch(() => {});
     }

--- a/src/lib/gs-delivery/worker.ts
+++ b/src/lib/gs-delivery/worker.ts
@@ -299,7 +299,12 @@ export async function enqueueVisitPickup(task: VisitPickupTask): Promise<void> {
       console.log(
         `[worker] ✅ 방문택배 폼 입력 완료 — 브라우저에서 확인 후 예약하기를 클릭해주세요`,
       );
-      // 페이지를 닫지 않음 — 사용자가 직접 확인하고 예약
+      // 페이지를 닫지 않음 — 사용자가 직접 확인하고 예약.
+      // 사용자가 페이지를 닫으면 브라우저도 함께 정리한다.
+      page.once("close", () => {
+        console.log("[worker] 방문택배 페이지 종료 감지 — 브라우저 정리");
+        void closeBrowser();
+      });
     } else {
       updateOrderStatusBatch(task.allOrderDbIds, "failed", result.error);
       addBookingLog(


### PR DESCRIPTION
## 관련 이슈
Closes #51

## 변경 내용
- **Idle 타임아웃 자동 종료** (`browser.ts` / `worker.ts`)
  - 큐 처리 완료 후 5분간 신규 작업이 없으면 Playwright Chromium 인스턴스를 자동 정리
  - 신규 작업 enqueue 시 타이머 취소
- **Visit-pickup 페이지 close 감지** (`worker.ts`)
  - 방문택배 페이지를 사용자가 닫으면 브라우저 자동 정리
- **SIGINT/SIGTERM graceful shutdown** (`instrumentation.ts`)
  - 프로세스 종료 시그널 수신 시 브라우저 닫고 종료

이전 PR #52와 동일한 변경 — 운영 작업 중 base SHA가 갱신되며 PR이 자동 close되어 새 PR로 재개.

## 코드 리뷰
- [x] 보안 감사 통과 (idle timer는 외부 입력 무관)
- [x] 타입 안전성 확인
- [x] 컨벤션 점검 완료

## 테스트
- [x] 큐 비었을 때 5분 후 자동 종료 동작 확인
- [x] 신규 작업 enqueue 시 타이머 취소 동작 확인
- [x] SIGINT 시 브라우저 정리 동작 확인