### PR TITLE
fix(build): Next.js 16 Edge Instrumentation 빌드 실패 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  serverExternalPackages: ["better-sqlite3", "playwright"],
+  serverExternalPackages: ["better-sqlite3", "playwright", "playwright-core"],
   outputFileTracingExcludes: {
     "*": [
       "node_modules/playwright-core/.local-browsers/**",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,9 @@
 /**
  * Next.js instrumentation hook — 서버 프로세스 시작 시 1회 호출.
  * - DEPLOY_MODE=server 이면 발송처리 자동 폴링을 시작한다.
- * - 종료 시그널(SIGINT/SIGTERM) 수신 시 Playwright 브라우저를 정리한다 (좀비 chromium 방지).
+ *
+ * Playwright 브라우저 SIGINT/SIGTERM 정리는 lib/gs-delivery/browser.ts에서
+ * 최초 launch 시점에 자체 등록한다 (Edge runtime 빌드에서 playwright 트레이스 회피).
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
@@ -11,27 +13,4 @@ export async function register() {
     startDispatchPolling();
     console.log("[instrumentation] 서버 모드 — 발송처리 폴링 자동 시작");
   }
-
-  registerShutdownHandlers();
-}
-
-let shutdownRegistered = false;
-
-function registerShutdownHandlers(): void {
-  if (shutdownRegistered) return;
-  shutdownRegistered = true;
-
-  const shutdown = async (signal: NodeJS.Signals) => {
-    console.log(`[instrumentation] ${signal} 수신 — graceful shutdown`);
-    try {
-      const { closeBrowser } = await import("@/lib/gs-delivery/browser");
-      await closeBrowser();
-    } catch (err) {
-      console.error("[instrumentation] 브라우저 정리 실패:", err);
-    }
-    process.exit(0);
-  };
-
-  process.once("SIGINT", () => void shutdown("SIGINT"));
-  process.once("SIGTERM", () => void shutdown("SIGTERM"));
 }

--- a/src/lib/gs-delivery/browser.ts
+++ b/src/lib/gs-delivery/browser.ts
@@ -26,6 +26,8 @@ const isServerMode = () => process.env.DEPLOY_MODE === "server";
 export async function getBrowser(): Promise<Browser> {
   if (browser?.isConnected()) return browser;
 
+  registerShutdownHandlers();
+
   browser = await chromium.launch({
     headless: isServerMode(),
     args: [
@@ -128,6 +130,26 @@ export function cancelIdleShutdown(): void {
     clearTimeout(idleTimer);
     idleTimer = null;
   }
+}
+
+let shutdownRegistered = false;
+
+function registerShutdownHandlers(): void {
+  if (shutdownRegistered) return;
+  shutdownRegistered = true;
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    console.log(`[browser] ${signal} 수신 — graceful shutdown`);
+    try {
+      await closeBrowser();
+    } catch (err) {
+      console.error("[browser] 브라우저 정리 실패:", err);
+    }
+    process.exit(0);
+  };
+
+  process.once("SIGINT", () => void shutdown("SIGINT"));
+  process.once("SIGTERM", () => void shutdown("SIGTERM"));
 }
 
 /** 브라우저 + 컨텍스트 전체 정리 (쿠키 저장 후 종료) */


### PR DESCRIPTION
## Summary
- Next.js 16의 Edge Instrumentation 빌드가 `instrumentation.ts → src/lib/gs-delivery/browser.ts → playwright-core`를 트레이스하면서 `chromium-bidi`, `electron` 모듈을 찾으려다 실패하여 `npm run build` 및 `npm run dev` 모두 막히던 문제 수정
- `instrumentation.ts`에서 Playwright 관련 dynamic import 제거 — Edge runtime 트레이스 경로 차단
- SIGINT/SIGTERM 브라우저 정리 핸들러를 `browser.ts`의 최초 `getBrowser()` 호출 시점에 자체 등록하도록 분리 (브라우저 launch가 일어난 프로세스에서만 동작)
- 보조 안전망으로 `serverExternalPackages`에 `playwright-core` 추가

## Test plan
- [x] `npm run dev` 정상 기동 (Edge Instrumentation 에러 없음)
- [x] GS택배 예약 정상 동작 — 실제 주문 예약 완료로 검증
- [x] 브라우저 launch 이후 SIGINT 수신 시 graceful shutdown 발동

🤖 Generated with [Claude Code](https://claude.com/claude-code)