### PR TITLE
chore(next16): middleware → proxy 파일 컨벤션 마이그레이션

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,6 @@
 /**
  * 앱 레벨 JWT 인증.
- * Edge Runtime 호환을 위해 jose 라이브러리 사용 (middleware에서 import).
+ * Edge Runtime 호환을 위해 jose 라이브러리 사용 (proxy에서 import).
  */
 
 import { SignJWT, jwtVerify } from "jose";
@@ -8,7 +8,7 @@ import { SignJWT, jwtVerify } from "jose";
 const authSecret = process.env.AUTH_SECRET;
 if (!authSecret) {
   throw new Error(
-    "AUTH_SECRET 환경 변수가 설정되지 않았습니다. .env.local 확인 필요."
+    "AUTH_SECRET 환경 변수가 설정되지 않았습니다. .env.local 확인 필요.",
   );
 }
 const SECRET = new TextEncoder().encode(authSecret);
@@ -29,7 +29,7 @@ export async function createSessionToken(username: string): Promise<string> {
 
 /** JWT 세션 토큰 검증 (유효하면 payload 반환, 아니면 null) */
 export async function verifySessionToken(
-  token: string
+  token: string,
 ): Promise<{ sub: string } | null> {
   try {
     const { payload } = await jwtVerify(token, SECRET, {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,11 +16,11 @@ const PUBLIC_PATHS = [
 
 function isPublicPath(pathname: string): boolean {
   return PUBLIC_PATHS.some((p) =>
-    p.endsWith("/") ? pathname.startsWith(p) : pathname === p
+    p.endsWith("/") ? pathname.startsWith(p) : pathname === p,
   );
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (isPublicPath(pathname)) {


### PR DESCRIPTION
## 배경
Next.js 16에서 `middleware.ts` 파일 컨벤션이 `proxy.ts`로 [renamed](https://nextjs.org/docs/messages/middleware-to-proxy). 현재 빌드 시 아래 경고 출력:

```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

향후 메이저 버전에서 제거될 가능성에 선제 대응.

## 변경
- `src/middleware.ts` → [src/proxy.ts](src/proxy.ts) (file rename)
- export 함수명 `middleware` → `proxy`
- [src/lib/auth.ts](src/lib/auth.ts) 상단 주석 일관성 정리 (`middleware에서 import` → `proxy에서 import`)

`config.matcher` 등 다른 부분은 변경 없음 — Next.js codemod 문서에 따라 rename만 필요.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [x] 빌드 출력에서 deprecation 경고 사라짐
- [x] 라우트 테이블에 `ƒ Proxy (Middleware)` 정상 표시
- [ ] 머지 후 서버 배포, 로그인 게이트(인증 필요 페이지 접근 시 `/login` 리다이렉트) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)