### PR TITLE
fix(visit-pickup): GS detail 재요청 throttle (세션 조기 만료 해결)

### DIFF
--- a/src/lib/dispatch-worker.ts
+++ b/src/lib/dispatch-worker.ts
@@ -8,6 +8,7 @@ import {
   applyVisitDispatchInfo,
   getBookedOrderGroups,
   getBookingVisitPickupGroups,
+  getMatchedVisitReservationNos,
   getUncheckedDispatchedOrders,
   updateDeliveryStatus,
   updateDispatchStatus,
@@ -25,6 +26,46 @@ let isRunning = false;
 /** 운송장 스크래핑 허용 시간대 (KST) */
 const SCRAPE_START_HOUR = 11; // 오전 11시
 const SCRAPE_END_HOUR = 18; // 오후 6시
+
+/**
+ * 방문택배 GS 상세페이지 재요청 throttle.
+ *
+ * PR #60 직후 dispatch-worker가 매 폴링마다 `scrapeVisitPickup([])` 호출 →
+ * GS list 방문 행 N건 전체의 detail POST를 매번 다시 요청 → GS가 봇 트래픽으로
+ * 인식해 세션을 빠르게 invalidate (2~3시간 안에 만료) 시키는 문제 발생.
+ *
+ * Fix: 한 번 detail fetch한 GS 예약번호는 TTL 동안 다시 fetch하지 않는다.
+ *   - DB 기반 known: getMatchedVisitReservationNos() — 이미 매칭 완료된 거
+ *   - 메모리 기반 recent: 매칭 실패했어도 같은 사이클에서 반복 fetch 방지
+ *
+ * 메모리 캐시는 PM2 재시작 시 비어 폴링 윈도우(11~18 KST) 안에선 자동으로
+ * 자기복구 (다음 사이클부터 다시 채워짐).
+ */
+const recentlyAttemptedVisits = new Map<string, number>();
+const VISIT_DETAIL_RETRY_INTERVAL_MS = 60 * 60 * 1000; // 60분
+
+function getKnownVisitReservationNos(): string[] {
+  const matched = getMatchedVisitReservationNos();
+  const now = Date.now();
+  const recent: string[] = [];
+  for (const [no, ts] of recentlyAttemptedVisits.entries()) {
+    if (now - ts > VISIT_DETAIL_RETRY_INTERVAL_MS) {
+      recentlyAttemptedVisits.delete(no);
+    } else {
+      recent.push(no);
+    }
+  }
+  return Array.from(new Set([...matched, ...recent]));
+}
+
+function markVisitReservationAttempted(reservationNo: string): void {
+  recentlyAttemptedVisits.set(reservationNo, Date.now());
+}
+
+/** 테스트용 — 캐시 초기화 */
+export function _resetVisitAttemptCacheForTest(): void {
+  recentlyAttemptedVisits.clear();
+}
 
 /** 현재 시간이 스크래핑 허용 시간대인지 확인 */
 function isWithinScrapeWindow(): boolean {
@@ -92,7 +133,14 @@ export async function checkAndDispatch(): Promise<CheckAndDispatchResult> {
       const visitGroups = getBookingVisitPickupGroups();
       if (visitGroups.length > 0) {
         try {
-          const visitInfos = await scrapeVisitPickup([]);
+          // 이미 처리/시도한 예약은 detail fetch에서 제외 → GS 봇 감지 회피
+          const knownNos = getKnownVisitReservationNos();
+          const visitInfos = await scrapeVisitPickup(knownNos);
+          // 새로 detail fetch한 예약(매칭 성공/실패 무관)을 캐시에 기록 →
+          // 다음 폴링부터 60분 동안 재요청 안 함.
+          for (const info of visitInfos) {
+            markVisitReservationAttempted(info.reservationNo);
+          }
           const { matched, unmatched, reservations } =
             applyVisitDispatchInfo(visitInfos);
           if (matched > 0 || unmatched > 0) {

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, ne } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNotNull, ne } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { bookingLogs, orders } from "@/lib/db/schema";
@@ -694,6 +694,31 @@ export function applyVisitDispatchInfo(infos: VisitDispatchInfo[]): {
     unmatched,
     reservations: Array.from(matchedReservations),
   };
+}
+
+/**
+ * 방문택배 타입 + 이미 GS 예약번호가 매핑된(=매칭 완료) 주문의 reservationNo 집합.
+ *
+ * 폴링이 scrapeVisitPickup을 호출할 때 이 집합을 knownReservationNos로 넘기면,
+ * 이미 매칭 완료된 예약의 GS 상세페이지를 다시 fetch하지 않는다.
+ * (PR #60 이후 dispatch-worker가 빈 배열로 호출 → GS 봇 감지 트리거 → 세션 조기 만료
+ *   되던 문제 해결용 헬퍼. 같은 폴링 사이클에서 반복 fetch 방지가 핵심.)
+ */
+export function getMatchedVisitReservationNos(): string[] {
+  const rows = db
+    .select({ no: orders.bookingReservationNo })
+    .from(orders)
+    .where(
+      and(
+        eq(orders.selectedDeliveryType, "visit"),
+        isNotNull(orders.bookingReservationNo),
+      ),
+    )
+    .all();
+
+  return Array.from(
+    new Set(rows.map((r) => r.no).filter((n): n is string => !!n)),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- PR #60 이후 dispatch-worker가 매 폴링(2분)마다 `scrapeVisitPickup([])` 호출 → GS list 방문 행 N건 전체의 detail POST를 매번 반복 요청 → GS가 봇으로 인식해 세션 조기 만료 (오늘 ~2시간 만에 만료 확인)
- 매칭 실패 그룹이 booking+visit 상태로 남는 한 시간당 ~270회 detail POST 폭주 + 매칭→발송 데드락
- 해결: 이미 처리/시도한 GS 예약번호를 `knownReservationNos`로 전달해 detail fetch에서 제외

## Root cause
오늘 운영 패턴:
1. 사용자 GS 방문택배 9건 결제 + 로컬 sync → 서버에 booking+visit 그룹 등록
2. 일부 그룹이 매칭 실패 (네이버 주문 동기화 시점 차이 등)로 booking 상태에 잔류
3. dispatch-worker가 매 사이클 `visitGroups.length > 0` → `scrapeVisitPickup([])` 호출
4. 빈 배열 = "알려진 예약 없음" → GS list의 모든 9건 detail POST 매번 반복
5. ~30 사이클(1시간) 누적 후 GS 봇 감지 → 세션 invalidate
6. 새 쿠키 받아도 같은 패턴 반복

어제 정상이었던 이유: 첫 사이클에 9건이 모두 매칭→booked로 전환 → `visitGroups.length === 0` → 그 이후 scrapeVisitPickup 호출 자체가 안 일어남.

## Changes
- `src/lib/orders.ts`: `getMatchedVisitReservationNos()` 추가 — visit 타입 + `bookingReservationNo` 있는 주문의 GS 예약번호 목록
- `src/lib/dispatch-worker.ts`:
  - 모듈 레벨 메모리 캐시 `recentlyAttemptedVisits` (60분 TTL)
  - `getKnownVisitReservationNos()` = DB matched + 메모리 recent
  - `scrapeVisitPickup(knownNos)` 호출 + 반환된 모든 reservationNo를 캐시에 기록

## Effect
- detail POST 트래픽: ~270회/시간 → (새 예약 수)/시간 (대부분 0)
- 매칭 실패 그룹은 60분 뒤 재시도 → 새 주문이 늦게 동기화돼도 자동 회복
- PM2 재시작 시 캐시 비워지지만, 다음 사이클부터 자동 복구

## Test plan
- [x] typecheck pass
- [x] 기존 11개 단위 테스트 pass (scrape-visit-pickup)
- [ ] 머지 후 서버 재배포
- [ ] 사용자 GS 재로그인 → 다음 폴링 사이클에서 detail fetch 0건(or 신규만) + 세션 유지 시간 모니터

## Follow-up (별 이슈 후보)
- 폴링 사이클에서 `scrape-tracking`과 `scrape-visit-pickup`이 GS list를 따로 fetch — 통합하면 list 트래픽도 절반
- 쿠키 만료 첫 발생 시 모바일 푸시 알림

🤖 Generated with [Claude Code](https://claude.com/claude-code)