### PR TITLE
fix(dispatch): 아침 예약 대응 — 운송장 스크래핑 윈도우 8시로 확대

### DIFF
--- a/src/lib/dispatch-worker.ts
+++ b/src/lib/dispatch-worker.ts
@@ -23,8 +23,18 @@ import {
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let isRunning = false;
 
-/** 운송장 스크래핑 허용 시간대 (KST) */
-const SCRAPE_START_HOUR = 11; // 오전 11시
+/**
+ * 운송장 스크래핑 허용 시간대 (KST).
+ *
+ * 하한이 8시인 이유: 스크래핑은 "처리할 booked 주문이 있을 때만" 돈다
+ * (checkAndDispatch의 `reservationNos.length > 0 && isWithinScrapeWindow()` 조건).
+ * 따라서 하한을 낮춰도 평소(11시 이후 예약)엔 아침에 처리할 주문이 없어
+ * 스크래핑하지 않는다 → 사실상 11시부터 동작. 반면 아침 일찍 예약한 날은
+ * 그 시각부터 폴링이 돌아 (1) 운송장을 일찍 잡고 (2) 2분 간격 요청이
+ * GS 세션을 keep-alive 해서 idle 만료를 막는다.
+ * → 날짜별 동적 윈도우 로직 없이 "아침 예약 날만 당겨지는" 효과를 얻는다.
+ */
+const SCRAPE_START_HOUR = 8; // 오전 8시
 const SCRAPE_END_HOUR = 18; // 오후 6시
 
 /**


### PR DESCRIPTION
## 배경
GS택배 세션이 idle 상태로 일정 시간이 지나면 만료된다. 로컬에서 쿠키를 동기화한 뒤 운송장 스크래핑 윈도우(기존 11시) 시작까지 간격이 길면, 첫 스크래핑 시점에 세션이 이미 만료돼 운송장을 받지 못하고 발송처리가 트리거되지 않는 경우가 있었다(아침 일찍 예약한 날).

## 변경
운송장 스크래핑 윈도우 하한을 **11시 → 8시**로 확대.

스크래핑은 처리할 booked 주문이 있을 때만 동작하므로(`reservationNos.length > 0` 조건), 하한을 낮춰도 평소(11시 이후 예약)엔 아침에 처리할 주문이 없어 그대로 11시부터 동작한다. 아침 일찍 예약한 날만 그 시각부터 폴링이 시작돼:
- 운송장을 일찍 감지하고
- 2분 간격 폴링이 세션을 keep-alive 해 idle 만료를 막는다

날짜별 동적 윈도우 로직 없이 "아침 예약 날만 윈도우가 당겨지는" 효과를 얻는다.

## 테스트
- 타입체크 통과
- 시간대 상수 변경이라 별도 단위 테스트는 추가하지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)